### PR TITLE
Install GStreamer and v4l2-ctl in Yocto image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ Targets:
                             MACHINE=$(MACHINE)
                             DISTRO=$(DISTRO)
                             SD_CARD_SIZE=$(SD_CARD_SIZE)
+    deploy              Deploy and install a Mender update to the target device
     help                (Default) Print usage information and exit
     tegraflash-extract  Extract the tegraflash archive from the latest build
     tegraflash-sdcard   Flash an SD card with the latest build
@@ -33,6 +34,10 @@ build:
 .PHONY: configure
 configure:
 	bin/configure-build
+
+.PHONY: deploy
+deploy:
+	bin/deploy
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export MACHINE ?= jetson-nano-devkit
 export DISTRO ?= tegrademo-mender
 export IMAGE ?= demo-image-base
 export SD_CARD_SIZE ?= 64G
-export DATA_PART_SIZE_MB ?= 40960
+export DATA_PART_SIZE_MB ?= 51200
 
 TEGRAFLASH_ARGS := -m $(MACHINE) -i $(IMAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export MACHINE ?= jetson-nano-devkit
 export DISTRO ?= tegrademo-mender
 export IMAGE ?= demo-image-base
 export SD_CARD_SIZE ?= 64G
+export DATA_PART_SIZE_MB ?= 40960
 
 TEGRAFLASH_ARGS := -m $(MACHINE) -i $(IMAGE)
 
@@ -18,6 +19,7 @@ Targets:
                             MACHINE=$(MACHINE)
                             DISTRO=$(DISTRO)
                             SD_CARD_SIZE=$(SD_CARD_SIZE)
+                            DATA_PART_SIZE_MB=$(DATA_PART_SIZE_MB)
     deploy              Deploy and install a Mender update to the target device
     help                (Default) Print usage information and exit
     tegraflash-extract  Extract the tegraflash archive from the latest build

--- a/bin/common
+++ b/bin/common
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+check_vars() {
+    local vars=("$@")
+    local status=0
+    for var in "${vars[@]}"; do
+        if [ -z "${!var}" ]; then
+            echo "'$var' must be set"
+            status=1
+        fi
+    done
+    if [ $status -ne 0 ]; then
+        exit $status
+    fi
+}

--- a/bin/configure-build
+++ b/bin/configure-build
@@ -6,10 +6,11 @@ THISDIR="$(dirname "$0")"
 . "$THISDIR/common"
 
 main() {
-    check_vars DISTRO MACHINE SD_CARD_SIZE
+    check_vars DISTRO MACHINE SD_CARD_SIZE DATA_PART_SIZE_MB
     create_build_dir
     add_layer meta-aesd
     set_local_conf TEGRAFLASH_SDCARD_SIZE "$SD_CARD_SIZE"
+    set_local_conf MENDER_DATA_PART_SIZE_MB "$DATA_PART_SIZE_MB"
     set_local_conf GST_VERSION 1.20.%
 }
 

--- a/bin/configure-build
+++ b/bin/configure-build
@@ -1,25 +1,16 @@
 #!/usr/bin/env bash
 
-REQUIRED_VARS=(
-    DISTRO
-    MACHINE
-    SD_CARD_SIZE
-)
+set -eo pipefail
+
+THISDIR="$(dirname "$0")"
+. "$THISDIR/common"
 
 main() {
-    check_env_vars
+    check_vars DISTRO MACHINE SD_CARD_SIZE
     create_build_dir
     add_layer meta-aesd
     set_local_conf TEGRAFLASH_SDCARD_SIZE "$SD_CARD_SIZE"
-}
-
-check_env_vars() {
-    for var in "${REQUIRED_VARS[@]}"; do
-        if [ -z "${!var}" ]; then
-            echo "Environment variable '$var' must be set"
-            exit 1
-        fi
-    done
+    set_local_conf GST_VERSION 1.20.%
 }
 
 create_build_dir() {

--- a/bin/deploy
+++ b/bin/deploy
@@ -10,7 +10,12 @@ check_vars IMAGE MACHINE
 SRC="build/tmp/deploy/images/$MACHINE/$IMAGE-$MACHINE.mender"
 DST="/tmp/update.mender"
 
+echo "Copying Mender artifact $SRC to jetson-dev"
 scp "$SRC" "jetson-dev:$DST"
 
+echo "Running 'mender install' on jetson-dev"
 # shellcheck disable=SC2029
 ssh jetson-dev "mender install $DST"
+
+echo "Rebooting jetson-dev"
+ssh jetson-dev "reboot" || true

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+THISDIR="$(dirname "$0")"
+. "$THISDIR/common"
+
+check_vars IMAGE MACHINE
+
+SRC="build/tmp/deploy/images/$MACHINE/$IMAGE-$MACHINE.mender"
+DST="/tmp/update.mender"
+
+scp "$SRC" "jetson-dev:$DST"
+
+# shellcheck disable=SC2029
+ssh jetson-dev "mender install $DST"

--- a/layers/meta-aesd/recipes-demo/images/demo-image-base.bbappend
+++ b/layers/meta-aesd/recipes-demo/images/demo-image-base.bbappend
@@ -2,8 +2,11 @@ CORE_IMAGE_EXTRA_INSTALL = " \
     gstreamer1.0-meta-base \
     gstreamer1.0-meta-debug \
     gstreamer1.0-meta-video \
+    gstreamer1.0-plugins-base-meta \
+    gstreamer1.0-plugins-good-meta \
     htop \
     iotop \
+    kernel-module-uvcvideo \
     tree \
     v4l-utils \
 "

--- a/layers/meta-aesd/recipes-demo/images/demo-image-base.bbappend
+++ b/layers/meta-aesd/recipes-demo/images/demo-image-base.bbappend
@@ -1,0 +1,9 @@
+CORE_IMAGE_EXTRA_INSTALL = " \
+    gstreamer1.0-meta-base \
+    gstreamer1.0-meta-debug \
+    gstreamer1.0-meta-video \
+    htop \
+    iotop \
+    tree \
+    v4l-utils \
+"


### PR DESCRIPTION
## Description

Code changes from testing and integrating GStreamer on the Jetson Nano.

- Added missing uvcvideo kernel driver
- Added missing GStreamer plugins
- Use newer GStreamer 1.20 instead of meta-tegra older version matched to containers
- Fine tuning of partition sizes to get a better Mender update time

## Issue Link

https://github.com/DomenicP/final-project-assignment-DomenicP/issues/5